### PR TITLE
Handle integers in commonEnv in values.yaml

### DIFF
--- a/charts/rails-k8s-demo/templates/environment/common-env.yaml
+++ b/charts/rails-k8s-demo/templates/environment/common-env.yaml
@@ -8,5 +8,5 @@ metadata:
 data:
   REDIS_URL: redis://{{ .Release.Name }}-redis-master.default.svc.cluster.local
 {{- range $key, $value := .Values.commonEnv }}
-  {{ $key }}: {{ $value }}
+  {{ $key }}: {{ $value | quote }}
 {{- end }}


### PR DESCRIPTION
Previously `RAILS_MAX_THREADS: 5` and `RAILS_MAX_THREADS: '5'` would hit `.../templates/environment/common-env.yaml failed: ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 5`.